### PR TITLE
justfile: Always attempt to modprobe br_netfilter

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,9 @@ up *ARGS: (_up "dev" ARGS)
 up-release *ARGS: (_up "release" ARGS)
 
 _up profile *ARGS: (build profile)
-	RUST_PROFILE={{profile}} docker compose up --wait {{ARGS}}
+    # Containers can't access the internet w/o br_netfilter loaded.
+    # Note that the modprobe invocatio is a no-op if br_netfilter is already loaded.
+    ( sudo modprobe br_netfilter || true ) && RUST_PROFILE={{profile}} docker compose up --wait {{ARGS}}
 
 # Follow logs of docker containers
 logs *ARGS:


### PR DESCRIPTION
On my AerynOS box, this doesn't get autoloaded for some reason, and this completely breaks the ability for containers to connect to the internet through the host's network.