### PR TITLE
README: Update for AerynOS, mention br_netfilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![docs](https://img.shields.io/badge/docs-passing-brightgreen)](https://serpent-os.github.io/infra-test/)
 
-SerpentOS service infrastructure
+AerynOS service infrastructure
 
 ## Prerequisites
 
@@ -10,9 +10,18 @@ SerpentOS service infrastructure
 - `just` is used as a runner tool to streamline this.
 
 ```sh
+# on AerynOS
+sudo moss sync -u
+sudo moss it docker just -y
+sudo usermod -a -G docker "${USER}"
+sudo systemctl enable --now docker.socket
+sudo systemctl reboot 
+```
+
+```sh
 # on solus:
 eopkg it docker docker-compose just
-sudo usermod -a -G docker
+sudo usermod -a -G docker "${USER}"
 sudo systemctl reboot
 ```
 
@@ -21,4 +30,8 @@ sudo systemctl reboot
 ```sh
 # Will build docker images and bring up `test/docker-compose.yaml`
 just up
+# Monitor service status and events
+just logs
+# Shut down containers
+just down
 ```


### PR DESCRIPTION
If the kernel module `br_netfilter` is not loaded on Linux, the containers won't be able to connect to the internet.